### PR TITLE
fix mount.UnmountAll may take long time to process and cause shim processes leaked

### DIFF
--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -315,6 +315,10 @@ func (p *Init) delete(ctx context.Context) error {
 			err = fmt.Errorf("failed rootfs umount: %w", err2)
 		}
 	}
+	if err == nil {
+		// mount.UnmountAll may take long time to process and the context may be timeout.
+		err = ctx.Err()
+	}
 	return err
 }
 


### PR DESCRIPTION


Signed-off-by: tfwang <tfwang@alauda.io>